### PR TITLE
Fix Fuse icon name so it is loaded correctly

### DIFF
--- a/net.sf.fuse_emulator.yaml
+++ b/net.sf.fuse_emulator.yaml
@@ -74,6 +74,7 @@ modules:
       - type: patch
         paths:
           - fuse-config-dir.patch
+          - rename-icon.patch
       - type: file
         path: net.sf.fuse_emulator.appdata.xml
       - type: script

--- a/rename-icon.patch
+++ b/rename-icon.patch
@@ -1,0 +1,24 @@
+Author: Alberto Garcia <berto@igalia.com>
+Subject: Flatpak renames the Fuse icon so update the code accordingly
+diff --git a/ui/gtk/gtkui.c b/ui/gtk/gtkui.c
+index 835b74e5..c11f5083 100644
+--- a/ui/gtk/gtkui.c
++++ b/ui/gtk/gtkui.c
+@@ -169,7 +169,7 @@ ui_init( int *argc, char ***argv )
+   gtkui_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+ 
+ #ifdef FUSE_ICON_AVAILABLE
+-  gtk_window_set_icon_name( GTK_WINDOW( gtkui_window ), "fuse" );
++  gtk_window_set_icon_name( GTK_WINDOW( gtkui_window ), "net.sf.fuse_emulator" );
+ #endif
+ 
+   settings = gtk_widget_get_settings( GTK_WIDGET( gtkui_window ) );
+@@ -675,7 +675,7 @@ menu_help_about( GtkAction *gtk_action GCC_UNUSED, gpointer data GCC_UNUSED )
+                          "comments", "The Free Unix Spectrum Emulator",
+                          "copyright", FUSE_COPYRIGHT,
+ #ifdef FUSE_ICON_AVAILABLE
+-                         "logo-icon-name", "fuse",
++                         "logo-icon-name", "net.sf.fuse_emulator",
+ #else
+                          "logo-icon-name", NULL,
+ #endif


### PR DESCRIPTION
The problem can be seen for example in the About dialog.