### PR TITLE
Add the SDL version of Fuse to the package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.sf.fuse_emulator.appdata.xml
+++ b/net.sf.fuse_emulator.appdata.xml
@@ -68,29 +68,33 @@
   </description>
   <screenshots>
     <screenshot width="1048" height="590" type="default">
+      <caption>Fuse running the 128 BASIC editor</caption>
       <image>
         https://raw.githubusercontent.com/flathub/net.sf.fuse_emulator/master/screenshots/fuse1.png
       </image>
     </screenshot>
     <screenshot width="1048" height="590">
+      <caption>Fuse loading The Lords of Midnight</caption>
       <image>
         https://raw.githubusercontent.com/flathub/net.sf.fuse_emulator/master/screenshots/fuse2.png
       </image>
     </screenshot>
     <screenshot width="1048" height="590">
+      <caption>Fuse running Head Over Heels</caption>
       <image>
         https://raw.githubusercontent.com/flathub/net.sf.fuse_emulator/master/screenshots/fuse3.png
       </image>
     </screenshot>
     <screenshot width="1048" height="590">
+      <caption>The Fuse debugger window</caption>
       <image>
         https://raw.githubusercontent.com/flathub/net.sf.fuse_emulator/master/screenshots/fuse4.png
       </image>
     </screenshot>
   </screenshots>
-  <developer_name>The Fuse development team</developer_name>
+  <developer id="net.sourceforge.fuse-emulator"><name>The Fuse development team</name></developer>
   <update_contact>fuse-emulator-devel_AT_lists.sourceforge.net</update_contact>
-  <url type="homepage">http://fuse-emulator.sourceforge.net/</url>
+  <url type="homepage">https://fuse-emulator.sourceforge.net/</url>
   <url type="bugtracker">https://sourceforge.net/p/fuse-emulator/bugs/</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>
@@ -121,4 +125,5 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
+  <launchable type="desktop-id">net.sf.fuse_emulator.desktop</launchable>
 </component>

--- a/net.sf.fuse_emulator.appdata.xml
+++ b/net.sf.fuse_emulator.appdata.xml
@@ -126,4 +126,5 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <launchable type="desktop-id">net.sf.fuse_emulator.desktop</launchable>
+  <launchable type="desktop-id">net.sf.fuse_emulator.sdl.desktop</launchable>
 </component>

--- a/net.sf.fuse_emulator.yaml
+++ b/net.sf.fuse_emulator.yaml
@@ -25,15 +25,19 @@ build-options:
   env:
     V: '1'
 cleanup:
+  - /bin/sdl-config
   - /include
   - /lib/*.a
   - /lib/*.la
   - /lib/*.so
   - /lib/pkgconfig
+  - /share/aclocal
   - /share/applications/mimeinfo.cache
   - /share/icons/hicolor/icon-theme.cache
   - /share/man
 modules:
+  # SDL 1.2 compatibility layer for SDL 2
+  - shared-modules/SDL/sdl12-compat.json
   # Audiofile is used for loading Spectrum data from WAV files
   - name: libaudiofile
     config-opts:
@@ -85,3 +89,35 @@ modules:
       - type: shell
         commands:
           - install -m644 -D net.sf.fuse_emulator.appdata.xml /app/share/appdata/net.sf.fuse_emulator.appdata.xml
+  # The SDL version of the emulator
+  - name: fuse-sdl
+    config-opts:
+      - --with-sdl
+      - --with-audio-driver=sdl
+      - --disable-desktop-integration
+    make-args:
+      - EXEEXT=-sdl
+    make-install-args:
+      - EXEEXT=-sdl
+    rm-configure: true
+    sources:
+      - type: archive
+        url: https://netcologne.dl.sourceforge.net/project/fuse-emulator/fuse/1.6.0/fuse-1.6.0.tar.gz
+        sha256: 3a8fedf2ffe947c571561bac55a59adad4c59338f74e449b7e7a67d9ca047096
+      - type: patch
+        paths:
+          - fuse-config-dir.patch
+          - set-generic-icon.patch
+      - type: script
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -f -i -I m4
+      - type: shell
+        commands:
+          - cp /app/share/applications/fuse.desktop /app/share/applications/net.sf.fuse_emulator.sdl.desktop
+          - >-
+             desktop-file-edit --set-key=Name --set-value='SDL Fuse'
+             --set-key=Exec --set-value='fuse-sdl %f'
+             --set-key=Icon --set-value='net.sf.fuse_emulator'
+             --remove-category=GTK
+             /app/share/applications/net.sf.fuse_emulator.sdl.desktop


### PR DESCRIPTION
With this patch Fuse is built twice, adding the SDL build to the package.

The good thing about the SDL version is that it has a full screen mode, which the GTK version doesn't.
