### PR TITLE
Mark net.sf.fuse_emulator as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+### Fuse Sinclair ZX Spectrum Emulator
+
+This app has been renamed from `net.sf.fuse_emulator` to [net.sourceforge.fuse_emulator.Fuse](https://flathub.org/apps/net.sourceforge.fuse_emulator.Fuse).
+
+This repository is obsolete, the new one is [here](https://github.com/flathub/net.sourceforge.fuse_emulator.Fuse).

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "end-of-life": "The application has been renamed to net.sourceforge.fuse_emulator.Fuse",
+  "end-of-life-rebase": "net.sourceforge.fuse_emulator.Fuse"
+}


### PR DESCRIPTION
Now that the new app ID [net.sourceforge.fuse_emulator.Fuse](https://flathub.org/apps/net.sourceforge.fuse_emulator.Fuse) is live and verified we can close this one.

I added the `flathub.json` file, shall I keep the rest of the files, delete them, or it doesn't matter?
